### PR TITLE
changing ref to repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Both the Web UI and REST API are only available after login in in the OpenAgri G
 ## Overview
 An overview of the endpoints provided by the FarmCalendar API can be seen at the [API.md](/API.md) file.
 ## Swagger Live Docs
-Use the [Online Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/openagri-eu/farmcalendar/refs/heads/main/schema.yml) to visualise the current API specification and documentation.
+Use the [Online Swagger Editor](https://editor-next.swagger.io/?url=https://raw.githubusercontent.com/agstack/OpenAgri-FarmCalendar/refs/heads/main/schema.yml) to visualise the current API specification and documentation.
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   web:
     build: .
-    image: ghcr.io/openagri-eu/farmcalendar:latest
+    image: ghcr.io/agstack/OpenAgri-FarmCalendar:latest
     command: /var/www/entrypoint.sh
     ports:
       - "${APP_PORT}:${APP_PORT}"


### PR DESCRIPTION
This should triger a new CI build once it's merged in main, and then we can ask to fix the docker image access in this project from private to public